### PR TITLE
Release 1.2.1.rc2

### DIFF
--- a/src/components/views/SubDocImage.js
+++ b/src/components/views/SubDocImage.js
@@ -12,10 +12,15 @@ const SubDocImage = function (data) {
         imagePath = data.config.prefix + dataValue;
       }
     } else {
-      dataValue = data.value;
+      dataValue = data.value;      
       if (data.config.prefix) {
         imagePath = data.config.prefix + dataValue;
-      } else {
+      } 
+      else if (data.config.inCrate) {
+        imagePath = data.ocfl_path + "/" + data.crate_uri[0] + "/" + data.value;
+        console.log(imagePath)
+      }
+      else {
         imagePath = dataValue
       }
     }

--- a/src/components/views/ViewTable.js
+++ b/src/components/views/ViewTable.js
@@ -139,7 +139,7 @@ const ViewTable = async function (data, doc) {
           const valueHtml = renderValue(data, sdcf, doc);
           if (valueHtml) {
             const row = $('<div class="row">');
-            const subDoc = SubDocImage({config: sdcf, value: valueHtml, element: row});
+            const subDoc = SubDocImage({config: sdcf, value: valueHtml, element: row, ocfl_path: data.config.apis.ocfl, crate_uri: data.main.doc.uri_id});
             nonEmptyDiv = true;
             list.append(subDoc);
           }


### PR DESCRIPTION
There is a requirement for the Seafood-collection dataset, to render images from within each crate in the SubDoc view.
This PR adds a new "inCrate" config option to SubDocImage which will prefix the OCFL and crate paths to the image filename.

This means that the HTML element then has:
`src="ocfl/f184debd-effa-4f91-ae88-15b958be7858/out_Man_01_November2020_December2020_WORKING.png"` where `ocfl` is pulled from the portal.json config file, and `f184debd-effa-4f91-ae88-15b958be7858` and `out_Man_01_November2020_December2020_WORKING.png` are pulled from SOLR.

An example of working config is 
`"viewFields": [
...
{
	    "label": "Image",
	    "field": "image",
	    "display": "SubDocImage",
	    "inCrate": "True"
}
]`

![inCrate_image](https://user-images.githubusercontent.com/19778036/138214948-5e605d65-fb03-45c2-96e4-3b1c6bda5d4b.png)